### PR TITLE
Fix crash when navigate from models.

### DIFF
--- a/src/rails_helper.ts
+++ b/src/rails_helper.ts
@@ -91,7 +91,7 @@ export class RailsHelper {
         break;
       case FileType.Model:
         const filePatten = join(prefix, this.fileName.replace(/\.rb$/, ''));
-        this.filePatten = inflection.pluralize(this.filePatten.toString());
+        this.filePatten = inflection.pluralize(filePatten.toString());
         break;
       case FileType.Layout:
         this.filePatten = join(


### PR DESCRIPTION
# Problem

When call `Rails:Navigation` on model file, I got error like belows

```
[2021-01-07 23:10:39.893] [exthost] [error] TypeError: Cannot read property 'toString' of null
	at RailsHelper.initPatten (/Users/nishimura.tomohiro/.vscode/extensions/bung87.rails-0.16.9/dist/extension.js:1468:67)
	at new RailsHelper (/Users/nishimura.tomohiro/.vscode/extensions/bung87.rails-0.16.9/dist/extension.js:1443:14)
	at railsNavigation (/Users/nishimura.tomohiro/.vscode/extensions/bung87.rails-0.16.9/dist/extension.js:31837:16)
```

# Fix

Use local variable instead of undefined property.