### PR TITLE
Deprecate extension in favor of Ruby LSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![Join the chat at https://gitter.im/vscode-rails/Lobby](https://badges.gitter.im/vscode-rails/Lobby.svg)](https://gitter.im/vscode-rails/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) 
 
+> [!IMPORTANT]
+> This extension is deprecated. Instead, we recommend using the `Shopify.ruby-lsp` VS Code Extension,
+> which will enable [a Rails addon automatically](https://shopify.github.io/ruby-lsp/rails-add-on.html).
 
 Ruby on Rails support for Visual Studio Code
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "rails",
     "displayName": "Rails",
     "description": "Ruby on Rails support for Visual Studio Code",
+    "deprecated": "Shopify.ruby-lsp"
     "version": "0.22.0",
     "publisher": "bung87",
     "icon": "rails.png",


### PR DESCRIPTION
Ruby LSP has an addon for Rails that will install automatically, and it's a good replacement to suggest to people.

I would do a final version bump to `0.22.1`, publish into the marketplace and then archive this repo.